### PR TITLE
pass additional arguments through to `r2d3::r2d3()` as a list of options

### DIFF
--- a/R/exposure_map_chart.R
+++ b/R/exposure_map_chart.R
@@ -36,7 +36,7 @@ exposure_map_chart <-
       width = width,
       height = height,
       container = "div",
-      ...
+      options = list(...)
     )
   }
 

--- a/R/exposure_pie_chart.R
+++ b/R/exposure_pie_chart.R
@@ -38,7 +38,7 @@ exposure_pie_chart <-
       width = width,
       height = height,
       container = "div",
-      ...
+      options = list(...)
     )
   }
 

--- a/R/peer_comparison_chart.R
+++ b/R/peer_comparison_chart.R
@@ -36,7 +36,7 @@ peer_comparison_chart <-
       width = width,
       height = height,
       container = "div",
-      ...
+      options = list(...)
     )
   }
 

--- a/R/tech_exposure_chart.R
+++ b/R/tech_exposure_chart.R
@@ -35,7 +35,7 @@ tech_exposure_chart <-
       width = width,
       height = height,
       container = "div",
-      ...
+      options = list(...)
     )
   }
 

--- a/R/trajectory_alignmemt_chart.R
+++ b/R/trajectory_alignmemt_chart.R
@@ -36,7 +36,7 @@ trajectory_alignment_chart <-
       width = width,
       height = height,
       container = "div",
-      ...
+      options = list(...)
     )
   }
 


### PR DESCRIPTION
Seems like this was never wired up properly. To pass additional options through `r2d3::r2d3()`, they must be passed to the `options` argument as a named list.